### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM python:3.10-slim-buster
-RUN mkdir "storage"
+FROM python:3.10-slim-bullseye
 COPY . /storage
 WORKDIR /storage
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-RUN apt-get update
-RUN apt-get install -y libpq-dev
-RUN apt-get install -y python3-pip
-RUN pip install -r requirements.txt
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install --no-install-recommends -y libpq-dev && apt-get clean && rm -rf /var/lib/apt/lists/* && pip install --no-cache-dir -r requirements.txt
+EXPOSE 8000
+ENTRYPOINT [ "/usr/local/bin/python3", "manage.py", "runserver", "0.0.0.0:8000" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.10-slim-bullseye
-COPY . /storage
+FROM python:3.11-slim-bullseye
+COPY ./requirements.txt /storage/
 WORKDIR /storage
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,14 @@
-version: '3.8'
+version: "3.8"
 
 services:
   web:
     build: .
-    command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/storage
     ports:
       - "8000:8000"
     env_file:
       - ./.env
-    expose:
-      - "8000"
     depends_on:
       - db
 
@@ -21,7 +18,6 @@ services:
       - postgres_data:/var/lib/postgresql/data/
     env_file:
       - ./.env
-
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - db
 
   db:
-    image: postgres
+    image: postgres:15
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     env_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.6.0
 Django==4.2
 python-dotenv==1.0.0
 sqlparse==0.4.3
+psycopg2-binary==2.9.6


### PR DESCRIPTION
Dockerfile fixes :

- Follow [hadolint](https://github.com/hadolint/hadolint) guide : 
  - Consolidate in a single `RUN` statement to limit the number of layers to a minimum
  - Disable `pip`'s and clean `apt` cache to limit image size
  - Ensure `apt` is in non-interactive mode
  - Add `=` to `ENV` statement
- No need to install `pip` again
- Set a hard-coded [entrypoint](https://aws.amazon.com/blogs/opensource/demystifying-entrypoint-cmd-docker/) to remove the use for `docker-compose`'s `command`
- Only copy `requirements.txt` into the Docker image, since the folder itself will be mounted by compose
- No need for a `mkdir` statement
- Update to python `3.11` image
- Add an `EXPOSE` statement

docker-compose.yml fixes : 

- Remove now redundant options (`command` and `expose`)
- Not pining Postgres to a main version is **extremely** dangerous, pinning to the latest version (`15`)